### PR TITLE
Set setup priority after Wi-Fi connection

### DIFF
--- a/components/sesame_lock/sesame_lock.h
+++ b/components/sesame_lock/sesame_lock.h
@@ -18,6 +18,10 @@ class SesameLock : public lock::Lock, public Component {
 	void init(const char* pubkey, const char* secret, const char* btaddr);
 	void setup() override {}
 	void loop() override;
+	float get_setup_priority() const override {
+		// After the Wi-Fi has been done setup
+		return setup_priority::AFTER_WIFI - 1.0f;
+	}
 
  private:
 	enum class state_t : int8_t { not_connected, connecting, authenticating, running, wait_reboot };

--- a/components/sesame_lock/sesame_lock.h
+++ b/components/sesame_lock/sesame_lock.h
@@ -20,7 +20,7 @@ class SesameLock : public lock::Lock, public Component {
 	void loop() override;
 	float get_setup_priority() const override {
 		// After the Wi-Fi has been done setup
-		return setup_priority::AFTER_WIFI - 1.0f;
+		return setup_priority::AFTER_WIFI;
 	}
 
  private:


### PR DESCRIPTION
Since the Wi-Fi connection becomes unstable depending on the board, set the setup priority after connecting to Wi-Fi.